### PR TITLE
インクリメンタルサーチの実装を行いました

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,72 @@
+$(function() {
+
+  function  appendUser(user){
+    var html = `
+              <div class="chat-group-user clearfix">
+                <p class="chat-group-user__name">${user.nickname}</p>
+                <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.nickname}">追加</div>
+              </div>
+              `;
+    $("#user-search-result").append(html);
+  }
+  function  appendErrMsgToHTML(){
+    var html = `
+               <div class="chat-group-user clearfix">
+                <p class="chat-group-user__name">ユーザーが見つかりません</p>
+               </div>`;
+    $("#user-search-result").append(html);
+  }
+
+  function addDeleteUser(nickname, id) {
+    let html = `
+    <div class="chat-group-user clearfix" id="${id}">
+      <p class="chat-group-user__name">${nickname}</p>
+      <div class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn" data-user-id="${id}" data-user-name="${nickname}">削除</div>
+    </div>`;
+    $(".js-add-user").append(html);
+  }
+  function addMember(userId) {
+    let html = `<input value="${userId}" name="group[user_ids][]" type="hidden" id="group_user_ids_${userId}" />`;
+    $(`#${userId}`).append(html);
+  }
+
+  $("#user-search-field").on("keyup", function() {
+    var input = $("#user-search-field").val();
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: {keyword: input},
+      dataType: 'json'
+    })
+    .done(function(users) {
+      $("#user-search-result").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user){
+          appendUser(user);
+        });
+      } else if (input.length == 0) {
+        return false;
+      } else {
+        appendErrMsgToHTML();
+      }
+    })
+    .fail(function() {
+      alert("ユーザー検索に失敗しました")
+    });
+  });
+
+  $(document).on("click", ".chat-group-user__btn--add", function(){
+    const userName = $(this).attr("data-user-name");
+    const userId = $(this).attr("data-user-id");
+    $(this)
+      .parent()
+      .remove();
+    addDeleteUser(userName, userId);
+    addMember(userId);
+  });
+  $(document).on("click", ".chat-group-user__btn--remove", function() {
+    $(this)
+      .parent()
+      .remove();
+  });
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,14 @@
 class UsersController < ApplicationController
+
+  def index
+    return nil if params[:keyword] == ""
+    @users = User.where(['nickname LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 
@@ -16,4 +26,3 @@ class UsersController < ApplicationController
     params.require(:user).permit(:name, :email)
   end
 end
- 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,15 +10,33 @@
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :nickname
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+
+      #chat-group-users.js-add-user
+        .chat-group-user.clearfix.js-chat-member
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p.chat-group-user__name= current_user.nickname
+
+        - group.users.each do |user|
+          - if current_user.nickname != user.nickname
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %p.chat-group-user__name
+                = user.nickname 
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+                削除
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id  user.id
+  json.nickname  user.nickname
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# WHAT
グループ作成時のユーザー検索をインクリメンタルサーチでできるように実装しました。
そのほかにも、以下の機能を実装しました。
・追加ボタンをクリックされたユーザーの名前を、チャットメンバーの部分に追加し、検索結果からは消す
・削除を押すと、チャットメンバーから削除される
・ログイン中のユーザーを追加済みの状態にする

# WHY
ユーザー目線で、グループ作成時のユーザー検索をインクリメンタルサーチでできるようにすると使いやすい。また、今までの実装では、ログイン中のユーザーをメンバーから外すことができたため。